### PR TITLE
Fix a typo

### DIFF
--- a/dxTarRead.c
+++ b/dxTarRead.c
@@ -51,7 +51,7 @@ const char* dxTarRead(const void* tarData, const long tarSize,
 #include <stdlib.h>
 
 int main(int argc, char **argv){
-    long fsize, mysize, readed;
+    long fsize, mysize, bytes_read;
     FILE* f;
     char* data;
     const char* myfile;
@@ -70,10 +70,10 @@ int main(int argc, char **argv){
     fseek(f, 0, SEEK_SET);
 
     data = (char*) malloc(fsize + 1);
-    readed = fread(data, 1, fsize, f);
+    bytes_read = fread(data, 1, fsize, f);
     fclose(f);
-    if( readed != fsize ){
-        puts("File not readed correctly!");
+    if( bytes_read != fsize ){
+        puts("File was not read correctly!");
         free(data);
         return -1;
     }


### PR DESCRIPTION
The past tense of `read` is `read`. There is no such word like `readed`.
See examples [here](http://pubs.opengroup.org/onlinepubs/009695399/functions/fread.html).